### PR TITLE
fixed link to tool

### DIFF
--- a/tutorial-rap3/your-tool-rap3.md
+++ b/tutorial-rap3/your-tool-rap3.md
@@ -1,6 +1,6 @@
 # Your tool: RAP3
 
-This section introduces the tool you will use during the course: RAP3. This tool stores Ampersand-scripts in which you can specify, analyze and build information systems. It runs in the cloud, so all you need is a browser and to [click here](http://rap.cs.ou.nl/RAP3) to start using it.
+This section introduces the tool you will use during the course: RAP3. This tool stores Ampersand-scripts in which you can specify, analyze and build information systems. It runs in the cloud, so all you need is a browser and to [click here if you are a student of the Open University](http://rap.cs.ou.nl/RAP3) or [here if you are not](http://ampersand.tarski.nl/RAP3/#/Login) to start using it.
 
 ## Login/Create account
 


### PR DESCRIPTION
It is highly undesireable to mix instructions for OU students with instructions for users that are not OU students. From an Ampersand perspective, everyone should be able to use the same documentation. If the OU likes to add its own way of working, that should be a separte thing. I suggest that the documentation is reviewed to accommodate for this separation.